### PR TITLE
Remove existing collections in the beginning

### DIFF
--- a/src/blended-dm.py
+++ b/src/blended-dm.py
@@ -26,6 +26,9 @@ def suppress_stdout():
 for collection in bpy.data.collections:
     bpy.data.collections.remove(collection)
 
+for object in bpy.data.objects:
+    bpy.data.objects.remove(object)
+    
 
 ###################
 ## Blender Setup ##

--- a/src/blended-dm.py
+++ b/src/blended-dm.py
@@ -18,6 +18,13 @@ def suppress_stdout():
         finally:
             sys.stdout = old_stdout
 
+            
+#######################################
+## Clear previously Generated Design ##
+#######################################
+
+for collection in bpy.data.collections:
+    bpy.data.collections.remove(collection)
 
 
 ###################


### PR DESCRIPTION
This is useful to be able to run the script without having to clear the scene first as well as rerunning the script after having changed parameters.